### PR TITLE
try to fix Apple build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -222,7 +222,9 @@ add_library(
     ${OVD_SRC}
 )
 set_target_properties(libopenvoronoi PROPERTIES PREFIX "")
-set_target_properties(libopenvoronoi PROPERTIES VERSION ${MY_VERSION}) 
+if (NOT APPLE)
+	set_target_properties(libopenvoronoi PROPERTIES VERSION ${MY_VERSION}) 
+endif (NOT APPLE)
 # link against libqd here. 
 # an alternative is to link libqd when an application using openvoronoi is built.
 target_link_libraries(libopenvoronoi ${Boost_LIBRARIES} ${QD_LIBRARY}) 
@@ -258,8 +260,9 @@ IF( ${BUILD_PYTHON_MODULE} MATCHES ON)
     )
     target_link_libraries(openvoronoi openvoronoi_static ${Boost_LIBRARIES} ${QD_LIBRARY}) 
     set_target_properties(openvoronoi PROPERTIES PREFIX "") 
-    set_target_properties(openvoronoi PROPERTIES VERSION ${MY_VERSION}) 
-
+    if (NOT APPLE)
+    	set_target_properties(openvoronoi PROPERTIES VERSION ${MY_VERSION}) 
+	endif (NOT APPLE)
     # this figures out where to install the Python modules
     execute_process(
         COMMAND python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()"
@@ -341,7 +344,7 @@ add_custom_target(coverage-report
     COMMAND lcov --directory ./ --zerocounters
     # COMMAND make ExperimentalCoverage
     # COMMAND ctest -D Experimental Coverage -R cpptest
-    COMMAND ctest -R cpptest -E "cpptest_arc\|cpptest_ttt_glyph_big_7\|cpptest_ttt_glyph_small_35" # exclude failing tests!
+    COMMAND ctest -R cpptest -E "cpptest_arc\\|cpptest_ttt_glyph_big_7\\|cpptest_ttt_glyph_small_35" # exclude failing tests!
     COMMAND lcov --directory ./ --capture  --output-file testcoverage.info # --base-directory ${CMAKE_SOURCE_DIR}
     COMMAND lcov --directory ./ --extract testcoverage.info \"*/openvoronoi*\" --output-file testcoverage_ext.info
     COMMAND genhtml --show-details --prefix \"${CMAKE_SOURCE_DIR}\" --output-directory coverage-report --title OpenVoronoi testcoverage_ext.info

--- a/src/test/cpptest_random_polygon/CMakeLists.txt
+++ b/src/test/cpptest_random_polygon/CMakeLists.txt
@@ -1,13 +1,7 @@
 SET(test_name "cpptest_random_polygon" )
 
 MESSAGE(STATUS "configuring c++ test: " ${test_name})
-set(SOURCE_FILES random_polygon.cpp)
-add_executable(${test_name} ${SOURCE_FILES})
-add_dependencies(${test_name}  libopenvoronoi)
 
-
-unset(Boost_LIBRARIES) # required because this contains boost-python when we come here
-find_package( Boost COMPONENTS program_options REQUIRED)
 # the rpg lib
 find_library(RPG_LIBRARY 
             NAMES randompolygon
@@ -16,16 +10,27 @@ find_library(RPG_LIBRARY
             REQUIRED
 )
 include_directories( /usr/local/include/randompolygon )
-target_link_libraries(${test_name} libopenvoronoi ${RPG_LIBRARY} ${Boost_LIBRARIES})
+if(RPG_LIBRARY_FOUND)
+	set(SOURCE_FILES random_polygon.cpp)
+	add_executable(${test_name} ${SOURCE_FILES})
+	add_dependencies(${test_name}  libopenvoronoi)
 
-ADD_TEST(${test_name} ${test_name}) # must provide --n option!
 
-ADD_TEST(${test_name}_help ${test_name} --help)
-set_property(
-    TEST ${test_name}_help
-    PROPERTY WILL_FAIL TRUE
-)
+	unset(Boost_LIBRARIES) # required because this contains boost-python when we come here
+	find_package( Boost COMPONENTS program_options REQUIRED)
 
-ADD_TEST(${test_name}_10 ${test_name} --n 10 )
-ADD_TEST(${test_name}_n10_s5 ${test_name} --n 10 --s 5)
+	target_link_libraries(${test_name} libopenvoronoi ${RPG_LIBRARY} ${Boost_LIBRARIES})
 
+	ADD_TEST(${test_name} ${test_name}) # must provide --n option!
+
+	ADD_TEST(${test_name}_help ${test_name} --help)
+	set_property(
+		TEST ${test_name}_help
+		PROPERTY WILL_FAIL TRUE
+	)
+
+	ADD_TEST(${test_name}_10 ${test_name} --n 10 )
+	ADD_TEST(${test_name}_n10_s5 ${test_name} --n 10 --s 5)
+else()
+	MESSAGE(STATUS "skipping c++ test: " ${test_name} ", dependency not found")
+endif()

--- a/src/test/cpptest_ttt_glyph/CMakeLists.txt
+++ b/src/test/cpptest_ttt_glyph/CMakeLists.txt
@@ -1,13 +1,6 @@
 SET(test_name "cpptest_ttt_glyph" )
 
 MESSAGE(STATUS "configuring c++ test: " ${test_name})
-set(SOURCE_FILES ttt_glyph.cpp)
-add_executable(${test_name} ${SOURCE_FILES})
-add_dependencies(${test_name}  libopenvoronoi)
-
-unset(Boost_LIBRARIES) # required because this contains boost-python when we come here
-find_package( Boost COMPONENTS program_options REQUIRED)
-
 # the ttt lib
 find_library(TTT_LIBRARY 
             NAMES truetypetracer
@@ -16,53 +9,63 @@ find_library(TTT_LIBRARY
             REQUIRED
 )
 include_directories( /usr/local/include/truetypetracer )
+	if( TTT_LIBRARY_FOUND )
+	set(SOURCE_FILES ttt_glyph.cpp)
+	add_executable(${test_name} ${SOURCE_FILES})
+	add_dependencies(${test_name}  libopenvoronoi)
 
-# freetype
-find_package(Freetype REQUIRED)
-if( FREETYPE_FOUND )
-   MESSAGE(STATUS "FREETYPE_LIBRARY is: " ${FREETYPE_LIBRARY})
-   MESSAGE(STATUS "FREETYPE_INCLUDE_DIRS is: " ${FREETYPE_INCLUDE_DIRS})
+	unset(Boost_LIBRARIES) # required because this contains boost-python when we come here
+	find_package( Boost COMPONENTS program_options REQUIRED)
+
+	# freetype
+	find_package(Freetype REQUIRED)
+	if( FREETYPE_FOUND )
+	   MESSAGE(STATUS "FREETYPE_LIBRARY is: " ${FREETYPE_LIBRARY})
+	   MESSAGE(STATUS "FREETYPE_INCLUDE_DIRS is: " ${FREETYPE_INCLUDE_DIRS})
+	endif()
+	include_directories(${FREETYPE_INCLUDE_DIRS})
+
+	target_link_libraries(${test_name} libopenvoronoi ${TTT_LIBRARY} ${Boost_LIBRARIES})
+
+	ADD_TEST(${test_name} ${test_name})
+
+	ADD_TEST(${test_name}_help ${test_name} --help)
+	set_property(
+		TEST ${test_name}_help
+		PROPERTY WILL_FAIL TRUE
+	)
+
+	ADD_TEST(${test_name}_fail ${test_name} --c 53) # illegal char index
+	set_property(
+		TEST ${test_name}_fail
+		PROPERTY WILL_FAIL TRUE
+	)
+
+	# --c options sets the glyph
+	# 0,1,2,3...51  corresponds to "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	set( CHARS   0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25) #  
+	set( CHARS2 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51) # 35
+
+	# --s option sets the scale. 3e-4 is a big character, 1e-6 is tiny
+	set( SCALES 0 1 2 3 4 )
+
+	# --d option sets subdivision of glyph, 50 is normal, 10 gives more segments
+	set( SUBS 60 50 40 30 20 10 )
+
+	foreach( CASE ${CHARS} )
+		foreach( SCALE ${SCALES} )
+			foreach( SUB ${SUBS} )
+				ADD_TEST(${test_name}_G${CASE}_s${SCALE}_sub${SUB} ${test_name} --c ${CASE} --s ${SCALE} --d ${SUB})
+			endforeach()
+		endforeach()
+	endforeach()
+	foreach( CASE ${CHARS2} )
+		foreach( SCALE ${SCALES} )
+			foreach( SUB ${SUBS} )
+				ADD_TEST(${test_name}_g${CASE}_s${SCALE}_sub${SUB} ${test_name} --c ${CASE} --s ${SCALE} --d ${SUB})
+			endforeach()
+		endforeach()
+	endforeach()
+else()
+	MESSAGE(STATUS "skipping c++ test: " ${test_name} ", dependency not found")
 endif()
-include_directories(${FREETYPE_INCLUDE_DIRS})
-
-target_link_libraries(${test_name} libopenvoronoi ${TTT_LIBRARY} ${Boost_LIBRARIES})
-
-ADD_TEST(${test_name} ${test_name})
-
-ADD_TEST(${test_name}_help ${test_name} --help)
-set_property(
-    TEST ${test_name}_help
-    PROPERTY WILL_FAIL TRUE
-)
-
-ADD_TEST(${test_name}_fail ${test_name} --c 53) # illegal char index
-set_property(
-    TEST ${test_name}_fail
-    PROPERTY WILL_FAIL TRUE
-)
-
-# --c options sets the glyph
-# 0,1,2,3...51  corresponds to "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-set( CHARS   0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25) #  
-set( CHARS2 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51) # 35
-
-# --s option sets the scale. 3e-4 is a big character, 1e-6 is tiny
-set( SCALES 0 1 2 3 4 )
-
-# --d option sets subdivision of glyph, 50 is normal, 10 gives more segments
-set( SUBS 60 50 40 30 20 10 )
-
-foreach( CASE ${CHARS} )
-    foreach( SCALE ${SCALES} )
-        foreach( SUB ${SUBS} )
-            ADD_TEST(${test_name}_G${CASE}_s${SCALE}_sub${SUB} ${test_name} --c ${CASE} --s ${SCALE} --d ${SUB})
-        endforeach()
-    endforeach()
-endforeach()
-foreach( CASE ${CHARS2} )
-    foreach( SCALE ${SCALES} )
-        foreach( SUB ${SUBS} )
-            ADD_TEST(${test_name}_g${CASE}_s${SCALE}_sub${SUB} ${test_name} --c ${CASE} --s ${SCALE} --d ${SUB})
-        endforeach()
-    endforeach()
-endforeach()


### PR DESCRIPTION
- avoid setting the version of libraries when on a mac (otherwise clang
complains with «invalid argument '-current_version 12.2.284' only
allowed with '-dynamiclib’ »)
- avoid compiling tests when their dependencies are not found

I also fixed some strange stuff around escapement in src/CMakeLists.txt line 344. 

3 arc tests still fail, but my understanding from the issues is that they were failing before.