### PR TITLE
Numerical and solver fixes

### DIFF
--- a/src/solvers/solver_lll.hpp
+++ b/src/solvers/solver_lll.hpp
@@ -68,8 +68,8 @@ int solve( Site* s1, double k1,
     
     unsigned int i = 0, j=1, k=2;
     qd_real d = chop( determinant( eq[i].a, eq[i].b, eq[i].k, 
-                                            eq[j].a, eq[j].b, eq[j].k, 
-                                            eq[k].a, eq[k].b, eq[k].k ) ); 
+                                   eq[j].a, eq[j].b, eq[j].k, 
+                                   eq[k].a, eq[k].b, eq[k].k ) ); 
     double det_eps = 1e-6;
     if ( fabs(d) > det_eps ) {
         qd_real t = determinant(  eq[i].a, eq[i].b, -eq[i].c, 
@@ -103,8 +103,8 @@ int solve( Site* s1, double k1,
                 s3 = sites[(i+2)%3];
                 k3 = kvals[(i+2)%3];
                 LLLPARASolver para_solver;
-                para_solver.set_debug(true);
-                para_solver.set_silent(false);
+                para_solver.set_debug(false);
+                para_solver.set_silent(true);
                 return para_solver.solve(s1, k1, s2, k2, s3, k3, slns);
             }
         }

--- a/src/solvers/solver_ppp.hpp
+++ b/src/solvers/solver_ppp.hpp
@@ -100,12 +100,21 @@ int solve( Site* s1, double, Site* s2, double, Site* s3, double, std::vector<Sol
         std::swap(pi,pj);
     assert( !pi.is_right(pj,pk) );
     // 2) point pk should have the largest angle. largest angle is opposite longest side.
-    double longest_side = (pi - pj).norm();
-    while (  ((pj - pk).norm() > longest_side) || (((pi - pk).norm() > longest_side)) ) { 
-        std::swap(pi,pj); // cyclic rotation of points until pk is opposite the longest side pi-pj
-        std::swap(pi,pk);  
-        longest_side = (pi - pj).norm();
+
+    double l[3] = {(pi - pj).norm(), (pj-pk).norm(), (pk-pi).norm()};
+    int longest_side = 0;
+    if (l[1] > l[0])            longest_side = 1;
+    if (l[2] > l[longest_side]) longest_side = 2;
+
+    if (longest_side == 1) {
+        std::swap(pi, pk);
+        std::swap(pi, pj);  	
     }
+    else if (longest_side == 2) {
+        std::swap(pi, pj); 
+        std::swap(pi, pk);  
+    }
+ 
     assert( !pi.is_right(pj,pk) );
     assert( (pi - pj).norm() >=  (pj - pk).norm() );
     assert( (pi - pj).norm() >=  (pk - pi).norm() );

--- a/src/voronoidiagram.cpp
+++ b/src/voronoidiagram.cpp
@@ -72,6 +72,7 @@ void VoronoiDiagram::initialize() {
     Point gen1 = Point( 0, 3.0*far_radius );
     Point gen2 = Point( -3.0*sqrt(3.0)*far_radius/2.0, -3.0*far_radius/2.0 );
     Point gen3 = Point( +3.0*sqrt(3.0)*far_radius/2.0, -3.0*far_radius/2.0 );
+
     // initial vd-vertices
     Point vd1 = Point(            0                 , -3.0*far_radius*far_multiplier    );
     Point vd2 = Point( +3.0*sqrt(3.0)*far_radius*far_multiplier/2.0, +3.0*far_radius*far_multiplier/2.0);


### PR DESCRIPTION
Hi Anders,

I've pushed two commits for openvoronoi - one for the vertex positioner, where the equidistance
constraint should help in situations where the t-filter is not able to discard solutions on the wrong side of s3.
This  happens in case the t-value does not vary sufficiently (e.g. due to S1/S2 being (nearly) parallel edges).

The infinite loop was something I observed after doing a cross-compile using mingw -
float behaviour can be quite esoteric at times :-) See the accompanying comment.
