### PR TITLE
Explicitly set cwd in version_string.cmake to (cmake) project src dir.

### DIFF
--- a/src/version_string.cmake
+++ b/src/version_string.cmake
@@ -13,6 +13,7 @@ if(GIT_FOUND)
         COMMAND ${GIT_EXECUTABLE} describe --tags 
         RESULT_VARIABLE res_var 
         OUTPUT_VARIABLE GIT_COM_ID 
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     )
     if( NOT ${res_var} EQUAL 0 )
         message( WARNING "Git failed (not a repo, or no tags)." )


### PR DESCRIPTION
The `version_string.cmake` file seemed to assume that its working directory was always somewhere inside the `openvoronoi` project dir. That is not always the case (especially not when including `openvoronoi/CMakeLists.txt` inside another project.

This change explicitly sets the working directory to `PROJECT_SOURCE_DIR` (which resolves to `openvoronoi/src` in this case), avoiding the issue described above.
