### PR TITLE
use "none" instead of "transparent" for fill values in simple svg

### DIFF
--- a/src/utility/simple_svg_1.0.0.hpp
+++ b/src/utility/simple_svg_1.0.0.hpp
@@ -217,7 +217,7 @@ namespace svg
         {
             std::stringstream ss;
             if (transparent)
-                ss << "transparent";
+                ss << "none";
             else
                 ss << "rgb(" << red << "," << green << "," << blue << ")";
             return ss.str();


### PR DESCRIPTION
Just a quick pull request.
Some svg viewers (eye of gnome, for example) are a bit happier with "none" instead of "transparent" (eye of gnome renders "transparent" as white).