### PR TITLE
Make OffsetLoopCompare operator const

### DIFF
--- a/src/offset_sorter.hpp
+++ b/src/offset_sorter.hpp
@@ -78,7 +78,7 @@ typedef boost::graph_traits<MachiningGraph>::vertex_iterator   MGVertexItr;
 class OffsetLoopCompare {
 public:
     /// sort predicate
-    bool operator() (OffsetLoop l1, OffsetLoop l2) {
+    bool operator() (OffsetLoop l1, OffsetLoop l2) const {
         return (l1.offset_distance > l2.offset_distance);
     }
 };


### PR DESCRIPTION
It appears to be required from C++17 onward that compare operator is declared as const.

Resolves #54

Not sure about backwards compatibility..?